### PR TITLE
Modify debug target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,11 +111,17 @@ run: $(BINARY) ## run the binary
 	@$(EMULATOR) -L $(EMULATION_LIB_PATH) $(BINARY)
 
 # Debug target to run the binary in debugging mode and wait for gdb connection
-debug: $(BINARY)  ## run in debugging mode and wait for gdb connection
+debugserver: $(BINARY)  ## run in debugging mode and wait for gdb connection
 	$(EMULATOR) -L $(EMULATION_LIB_PATH) -g $(DEBUG_PORT) $(BINARY)
 
 # Connect target to start a GDB session and connect to the qemu debugger
 connect: ## connect gdb
+	$(DEBUGGER) -q --nh -ex 'set architecture $(ARCH)' -ex 'file $(BINARY)' -ex 'target remote localhost:$(DEBUG_PORT)' -ex 'layout regs'
+
+# Debug target to start a debug server and automatically connect gdb
+debug: $(BINARY) ## run a debug server and connect gdb
+	$(EMULATOR) -L $(EMULATION_LIB_PATH) -g $(DEBUG_PORT) $(BINARY) & \
+	sleep 1 && \
 	$(DEBUGGER) -q --nh -ex 'set architecture $(ARCH)' -ex 'file $(BINARY)' -ex 'target remote localhost:$(DEBUG_PORT)' -ex 'layout regs'
 
 # Clean target to remove generated files

--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ This Makefile is designed to simplify the process of cross-compiling C++ and ass
   
 ## Debugging
 
-- To run the binary with GDB, use the `debug` target. It will start the QEMU emulator in debugging mode and wait for a GDB connection on port `1234`.
+- To debug, run:
+    ```bash
+    make debug
+    ```
+
+- You can also run the binary with GDB, using the `debugserver` target. It will start the QEMU emulator in debugging mode and wait for a GDB connection on port `1234`.
 
     To connect GDB to the debugger, run:
 


### PR DESCRIPTION
Simplify the Makefile by combining the `debugserver` (initially named `debug`) and connect targets into a single unified `debug` target. The updated `debug` target runs the binary in debugging mode in the background and automatically connects to the debug server within the same terminal, removing the need for a separate terminal.